### PR TITLE
crishim/pkg/kubeadvertise: remove commented-out code

### DIFF
--- a/crishim/pkg/kubeadvertise/advertise_device.go
+++ b/crishim/pkg/kubeadvertise/advertise_device.go
@@ -80,7 +80,6 @@ func (da *DeviceAdvertiser) AdvertiseLoop(intervalMs int, tryAgainIntervalMs int
 						}
 						if err == nil {
 							tickChanOnErr.Stop()
-							//close(tickChanOnErr.C)
 							break // back to original timer
 						}
 					}


### PR DESCRIPTION
`close` is commented-out without explanation and TODO note,
so it only pollutes code right now. Should be removed.

https://open.microsoft.com/2018/09/30/join-hacktoberfest-2018-celebration-microsoft
Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>